### PR TITLE
modify the minDate and maxDate values

### DIFF
--- a/doc/datepicker/example/index.html
+++ b/doc/datepicker/example/index.html
@@ -986,7 +986,7 @@
 <input class="datepicker-demo view-mode-example" /></p>
 <h2 id="mindate">minDate<a class="headerlink" href="#mindate" title="Permanent link">&para;</a></h2>
 <div class="codehilite"><pre><span></span><span class="nx">$</span><span class="p">(</span><span class="s1">&#39;.min-date-example&#39;</span><span class="p">).</span><span class="nx">persianDatepicker</span><span class="p">({</span>
-    <span class="nx">minDate</span><span class="o">:</span> <span class="k">new</span> <span class="nx">persianDate</span><span class="p">().</span><span class="nx">unix</span><span class="p">()</span>
+    <span class="nx">minDate</span><span class="o">:</span> <span class="k">new</span> <span class="nx">persianDate</span><span class="p">().</span><span class="nx">valueOf</span><span class="p">()</span>
 <span class="p">});</span>
 </pre></div>
 
@@ -999,7 +999,7 @@
 <input class="datepicker-demo min-date-example" /></p>
 <h2 id="maxdate">maxDate<a class="headerlink" href="#maxdate" title="Permanent link">&para;</a></h2>
 <div class="codehilite"><pre><span></span><span class="nx">$</span><span class="p">(</span><span class="s1">&#39;.max-date-example&#39;</span><span class="p">).</span><span class="nx">persianDatepicker</span><span class="p">({</span>
-    <span class="nx">maxDate</span><span class="o">:</span> <span class="k">new</span> <span class="nx">persianDate</span><span class="p">().</span><span class="nx">unix</span><span class="p">()</span>
+    <span class="nx">maxDate</span><span class="o">:</span> <span class="k">new</span> <span class="nx">persianDate</span><span class="p">().</span><span class="nx">valueOf</span><span class="p">()</span>
 <span class="p">});</span>
 </pre></div>
 

--- a/src/datepicker/example.md
+++ b/src/datepicker/example.md
@@ -307,7 +307,7 @@ $('.view-mode-example').persianDatepicker({
 
 ```javascript
 $('.min-date-example').persianDatepicker({
-    minDate: new persianDate().unix()
+    minDate: new persianDate().valueOf()
 });
 ```
 
@@ -323,7 +323,7 @@ $('.min-date-example').persianDatepicker({
 
 ```javascript
 $('.max-date-example').persianDatepicker({
-    maxDate: new persianDate().unix()
+    maxDate: new persianDate().valueOf()
 });
 ```
 


### PR DESCRIPTION
[#248](https://github.com/babakhani/pwt.datepicker/issues/248)
In the minDate/maxDate example section, you mistakenly provided the value "UTC in seconds".

http://babakhani.github.io/PersianWebToolkit/doc/datepicker/example/#mindate
The unix() method returns the UTC time in seconds.

However, the values minDate and maxDate should be entered as "UTC milliseconds" to work correctly (not in seconds). If entered in seconds, the minimum selectable date will be approximately 50 years before the expected date.

The code snippet below demonstrates the difference.
Please check this jsFiddle:
https://jsfiddle.net/Khakshoor/yjpk93aw/2/